### PR TITLE
Update build.gradle added namespace to support new gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'xyz.justsoft.video_thumbnail'
     compileSdkVersion 33
 
     defaultConfig {


### PR DESCRIPTION
```
Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   Namespace not specified. Please specify a namespace in the module's build.gradle file like so:

     android {
         namespace 'com.example.namespace'
     }
```