### PR TITLE
build(ios): podspec file name and s.name needs to be same as library name

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.2
+  flutter_lints: ^3.0.1
 
 flutter:
   uses-material-design: true

--- a/ios/get_thumbnail_video.podspec
+++ b/ios/get_thumbnail_video.podspec
@@ -2,7 +2,7 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
 #
 Pod::Spec.new do |s|
-  s.name             = 'video_thumbnail'
+  s.name             = 'get_thumbnail_video'
   s.version          = '0.0.1'
   s.summary          = 'A new flutter plugin project.'
   s.description      = <<-DESC

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.2
-  lints: ^2.1.1
+  flutter_lints: ^3.0.1
+  lints: ^3.0.0
 
 flutter:
   plugin:


### PR DESCRIPTION
for ios, podspec file name and s.name needs to be same as library name, otherwise `pod install` will fail, giving error `can't find get_video_thumbnail`