### PR TITLE
feat: relax plugin environment to support flutter 3.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Upcoming
+* Relaxed the environment constraints for the plugin to support flutter v3.22.0
+
 ## 0.7.2
 
 * refactor(android): improved build and code optimization

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,8 +5,8 @@ homepage:
 repository: https://github.com/Alberto-Monteiro/video_thumbnail
 
 environment:
-  sdk: ^3.5.4
-  flutter: '>=3.3.0'
+  sdk: ^3.4.0
+  flutter: ^3.22.0
 
 dependencies:
   flutter:
@@ -20,7 +20,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ">=4.0.0 <6.0.0"
 
 flutter:
   plugin:


### PR DESCRIPTION
We currently have to a policy to use the latest N - 1 version of Flutter in our workspace. By relaxing the environment, it will be  good to use.